### PR TITLE
Qt 5.15.14 with OpenSSL 3.3.0 support.

### DIFF
--- a/.github/workflows/build-qt-5.15.yml
+++ b/.github/workflows/build-qt-5.15.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Upload patched Qt sources
         uses: actions/upload-artifact@v4
         with:
-          name: Qt 5.15.13 patched src
+          name: Qt 5.15.14 patched src
           path: |
             src_archive/*
           compression-level: 9
@@ -32,7 +32,7 @@ jobs:
       - name: Upload built Qt
         uses: actions/upload-artifact@v4
         with:
-          name: Qt 5.15.13 x64
+          name: Qt 5.15.14 x64
           path: |
             archive/*
           compression-level: 9
@@ -56,7 +56,7 @@ jobs:
       - name: Upload built Qt
         uses: actions/upload-artifact@v4
         with:
-          name: Qt 5.15.13 x86
+          name: Qt 5.15.14 x86
           path: |
             archive/*
           compression-level: 9

--- a/build_sources.cmd
+++ b/build_sources.cmd
@@ -1,3 +1,5 @@
+set "qt_version=5.15.14"
+
 if %1 == x64 (
     set build_arch=x64
     set "PATH=%~dp0src\qtbase\bin;%~dp0src\gnuwin32\bin;%~dp0jom;%PATH%"
@@ -8,10 +10,10 @@ if %1 == x64 (
     nmake install
     popd
     pushd %~dp0src\
-    call configure.bat -release -opensource -confirm-license -prefix %~dp0bin\5.15.13\msvc2019_64 -platform win32-msvc -openssl-linked OPENSSL_PREFIX="%~dp0openssl-win64" -nomake tests -nomake examples -skip qtdoc -skip qtwebengine
+    call configure.bat -release -opensource -confirm-license -prefix %~dp0bin\%qt_version%\msvc2019_64 -platform win32-msvc -openssl-linked OPENSSL_PREFIX="%~dp0openssl-win64" -nomake tests -nomake examples -skip qtdoc -skip qtwebengine
     jom
     if %ERRORLEVEL% == 0 jom install
-    if %ERRORLEVEL% == 0 mkdir %~dp0archive && "C:\Program Files\7-Zip\7z.exe" a -t7z -mx=9 -mfb=273 -ms -md=31 -myx=9 -mtm=- -mmt -mmtf -md=1536m -mmf=bt3 -mmc=10000 -mpb=0 -mlc=0 %~dp0archive\qt-everywhere-5.15.13-Windows_10-MSVC2019-x86_64.7z %~dp0bin\5.15.13
+    if %ERRORLEVEL% == 0 mkdir %~dp0archive && "C:\Program Files\7-Zip\7z.exe" a -t7z -mx=9 -mfb=273 -ms -md=31 -myx=9 -mtm=- -mmt -mmtf -md=1536m -mmf=bt3 -mmc=10000 -mpb=0 -mlc=0 %~dp0archive\qt-everywhere-%qt_version%-Windows_10-MSVC2019-x86_64.7z %~dp0bin\%qt_version%
 )
 
 if %1 == Win32 (
@@ -24,8 +26,8 @@ pushd %~dp0src\openssl\
     nmake install
     popd
     pushd %~dp0src\
-    call configure.bat -release -opensource -confirm-license -prefix %~dp0bin\5.15.13\msvc2019 -platform win32-msvc -openssl-linked OPENSSL_PREFIX="%~dp0openssl-win32" -nomake tests -nomake examples -skip qtdoc -skip qtwebengine
+    call configure.bat -release -opensource -confirm-license -prefix %~dp0bin\%qt_version%\msvc2019 -platform win32-msvc -openssl-linked OPENSSL_PREFIX="%~dp0openssl-win32" -nomake tests -nomake examples -skip qtdoc -skip qtwebengine
     jom
     if %ERRORLEVEL% == 0 jom install
-    if %ERRORLEVEL% == 0 mkdir %~dp0archive && "C:\Program Files\7-Zip\7z.exe" a -t7z -mx=9 -mfb=273 -ms -md=31 -myx=9 -mtm=- -mmt -mmtf -md=1536m -mmf=bt3 -mmc=10000 -mpb=0 -mlc=0 %~dp0archive\qt-everywhere-5.15.13-Windows_10-MSVC2019-x86.7z %~dp0bin\5.15.13
+    if %ERRORLEVEL% == 0 mkdir %~dp0archive && "C:\Program Files\7-Zip\7z.exe" a -t7z -mx=9 -mfb=273 -ms -md=31 -myx=9 -mtm=- -mmt -mmtf -md=1536m -mmf=bt3 -mmc=10000 -mpb=0 -mlc=0 %~dp0archive\qt-everywhere-%qt_version%-Windows_10-MSVC2019-x86.7z %~dp0bin\%qt_version%
 )

--- a/download_sources.cmd
+++ b/download_sources.cmd
@@ -1,52 +1,130 @@
-if exist %~dp0qt-everywhere-src-5.15.13\configure.bat goto done
+set "qt_version=5.15.14"
+set "qt_source_url=https://download.qt.io/archive/qt/5.15/%qt_version%/single/qt-everywhere-opensource-src-%qt_version%.zip"
+set "qt_patch_url=https://download.qt.io/archive/qt/5.15"
+set "openssl_version=3.3.0"
+set "openssl_source_url=https://github.com/openssl/openssl/releases/download/openssl-%openssl_version%/openssl-%openssl_version%.tar.gz"
+set "bDir=%~dp0"
+set "bDir=%bDir:~0,-1%"
+set "EOL=CRLF"
+if "%EOL%" == "LF" (
+    echo Patch file line endings will be converted to LF ^(Unix^) using Dos2Unix.
+    set "EOLconverter=dos2unix"
+) else (
+    echo Patch file line endings will be converted to CRLF ^(Windows^) using Unix2Dos.
+    set "EOLconverter=unix2dos"
+)
 
-REM Downloading Qt 5.15.13 source code...
-curl -LsSO --output-dir %~dp0 https://download.qt.io/archive/qt/5.15/5.15.13/single/qt-everywhere-opensource-src-5.15.13.zip
-"C:\Program Files\7-Zip\7z.exe" x -aoa -o%~dp0 %~dp0qt-everywhere-opensource-src-5.15.13.zip
-move %~dp0qt-everywhere-src-5.15.13 %~dp0src
+if exist "%bDir%\qt-everywhere-src-%qt_version%\configure.bat" goto done
 
-REM Downloading Qt 5.15.13 security patches...
-curl -LsSO --output-dir %~dp0src\qtsvg\ https://download.qt.io/archive/qt/5.15/CVE-2023-32573-qtsvg-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2023-32762-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2023-32763-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2023-33285-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2023-34410-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2023-37369-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2023-38197-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2023-43114-5.15.patch
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/0001-CVE-2023-51714-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/0002-CVE-2023-51714-qtbase-5.15.diff
-curl -LsSO --output-dir %~dp0src\qtbase\ https://download.qt.io/archive/qt/5.15/CVE-2024-25580-qtbase-5.15.diff
+REM Downloading Qt 5.15 source code...
+echo Downloading Qt %qt_version% source code...
+curl -LsSO --output-dir "%bDir%" "%qt_source_url%"
+"C:\Program Files\7-Zip\7z.exe" x -aoa -o"%bDir%" "%bDir%\qt-everywhere-opensource-src-%qt_version%.zip"
+move "%bDir%\qt-everywhere-src-%qt_version%" "%bDir%\src"
+
+REM Downloading Qt 5.15 security patches...
+echo Downloading Qt %qt_version% security patches...
+
+if "%qt_version%" == "5.15.13" echo Qt version is %qt_version% & goto verMin13
+if "%qt_version%" == "5.15.14" echo Qt version is %qt_version% & goto verMin14
+if "%qt_version%" == "5.15.15" echo Qt version is %qt_version% & goto verMin15
+if "%qt_version%" == "5.15.16" echo Qt version is %qt_version% & goto verMin16
+if "%qt_version%" == "5.15.17" echo Qt version is %qt_version% & goto verMin17
+if "%qt_version%" == "5.15.18" echo Qt version is %qt_version% & goto verMin18
+if "%qt_version%" == "5.15.19" echo Qt version is %qt_version% & goto verMin19
+
+:verMin13
+curl -LsSO --output-dir "%bDir%\src\qtsvg" "%qt_patch_url%/CVE-2023-32573-qtsvg-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2023-32762-qtbase-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2023-33285-qtbase-5.15.diff"
+:verMin14
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2023-32763-qtbase-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2023-34410-qtbase-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2023-37369-qtbase-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2023-38197-qtbase-5.15.diff"
+:verMin15
+curl -LsSO --output-dir "%bDir%\src\qtimageformats" "%qt_patch_url%/CVE-2023-4863-5.15.patch"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2023-43114-5.15.patch"
+:verMin16
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/0001-CVE-2023-51714-qtbase-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/0002-CVE-2023-51714-qtbase-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtbase" "%qt_patch_url%/CVE-2024-25580-qtbase-5.15.diff"
+curl -LsSO --output-dir "%bDir%\src\qtnetworkauth" "%qt_patch_url%/CVE-2024-36048-qtnetworkauth-5.15.diff"
+:verMin17
+:verMin18
+:verMin19
+
 
 REM Install GNU Patch tool (from Chocolatey)...
 choco install patch -y
 
+REM Install Dos2Unix / Unix2Dos - Text file format converters
+choco install dos2unix -y
+
 REM Patch Qt sources...
-pushd %~dp0src\qtbase\
-patch -p1 -i CVE-2023-32762-qtbase-5.15.diff
-patch -p1 -i CVE-2023-32763-qtbase-5.15.diff
-patch -p1 -i CVE-2023-33285-qtbase-5.15.diff
-patch -p1 -i CVE-2023-34410-qtbase-5.15.diff
-patch -p1 -i CVE-2023-37369-qtbase-5.15.diff
-patch -p1 -i CVE-2023-38197-qtbase-5.15.diff
-patch -p1 -i CVE-2023-43114-5.15.patch
-patch -p1 -i 0001-CVE-2023-51714-qtbase-5.15.diff
-patch -p1 -i 0002-CVE-2023-51714-qtbase-5.15.diff
-patch -p1 -i CVE-2024-25580-qtbase-5.15.diff
+pushd "%bDir%\src\qtsvg"
+set qtsvg_patches="CVE-2023-32573-qtsvg-5.15.diff"
+for %%i in (%qtsvg_patches%) do (
+    if exist "%%i" (
+        echo Applying patch "%%i"
+        %EOLconverter% --verbose "%%i"
+        patch -p1 --verbose -u -i "%%i"
+    ) else (
+        echo File "%%i" does not exist. Skipping...
+    )
+)
 popd
-pushd %~dp0src\qtsvg\
-patch -p1 -i CVE-2023-32573-qtsvg-5.15.diff
+
+pushd "%bDir%\src\qtbase"
+set qtbase_patches="CVE-2023-32762-qtbase-5.15.diff" "CVE-2023-33285-qtbase-5.15.diff" "CVE-2023-32763-qtbase-5.15.diff" "CVE-2023-34410-qtbase-5.15.diff" "CVE-2023-37369-qtbase-5.15.diff" "CVE-2023-38197-qtbase-5.15.diff" "CVE-2023-43114-5.15.patch" "0001-CVE-2023-51714-qtbase-5.15.diff" "0002-CVE-2023-51714-qtbase-5.15.diff" "CVE-2024-25580-qtbase-5.15.diff"
+for %%i in (%qtbase_patches%) do (
+    if exist "%%i" (
+        echo Applying patch "%%i"
+        %EOLconverter% --verbose "%%i"
+        patch -p1 --verbose -u -i "%%i"
+    ) else (
+        echo File "%%i" does not exist. Skipping...
+    )
+)
+popd
+
+pushd "%bDir%\src\qtimageformats"
+set qtimageformats_patches="CVE-2023-4863-5.15.patch"
+for %%i in (%qtimageformats_patches%) do (
+    if exist "%%i" (
+        echo Applying patch "%%i"
+        %EOLconverter% --verbose "%%i"
+        patch -p1 --verbose -u -i "%%i"
+    ) else (
+        echo File "%%i" does not exist. Skipping...
+    )
+)
+popd
+
+pushd "%bDir%\src\qtnetworkauth"
+set qtnetworkauth_patches="CVE-2024-36048-qtnetworkauth-5.15.diff"
+for %%i in (%qtnetworkauth_patches%) do (
+    if exist "%%i" (
+        echo Applying patch "%%i"
+        %EOLconverter% --verbose "%%i"
+        patch -p1 --verbose -u -i "%%i"
+    ) else (
+        echo File "%%i" does not exist. Skipping...
+    )
+)
 popd
 
 REM Download openssl sources...
-git clone -b OpenSSL_1_1_1p --recursive --depth 1 https://github.com/DavidXanatos/openssl.git %~dp0src\openssl
+curl -LsSO --output-dir "%bDir%" "%openssl_source_url%"
+tar -xzf "openssl-%openssl_version%.tar.gz"
+move "%bDir%\openssl-%openssl_version%" "%bDir%\src\openssl"
 
-if %1 == repack (
+if "%1" == "repack" (
     REM Pack patched Qt sources...
-    mkdir %~dp0src_archive && tar -cf src_archive/qt-everywhere-opensource-src-5.15.13-patched-openssl.tar %~dp0src
+    mkdir "%bDir%\src_archive" && tar -cf "src_archive/qt-everywhere-opensource-src-%qt_version%-patched-openssl.tar" "%bDir%\src"
 )
 
 :done
 
-REM dir %~dp0
-REM dir %~dp0src\
+REM dir %bDir%
+REM dir %bDir%\src


### PR DESCRIPTION
Qt 5.15.14 with OpenSSL 3.3.0 support.

I also resolved the issue where some patches couldn't apply to the source code due to differences in line breaks.